### PR TITLE
Deploy: add docker-compose and NixOS Modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,6 @@ all: build/server
 install: all
 	install -D --mode=755 --no-target-directory build/server $(BIN_NAME)
 
-.PHONY: stop watch all test compose compose-rebuild
-
 # Deployment
 # ----------
 .PHONY: push-goose push-rss-aggre push-images
@@ -45,6 +43,8 @@ push-rss-aggre:
 
 # Development niceties
 # --------------------
+
+.PHONY: stop watch all test compose compose-rebuild
 
 pidfile: build/server
 	$(MAKE) stop

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,8 +1,13 @@
 services:
   rss-aggre:
-    image: "rss-aggre:latest"
+    image: "horriblename/rss-aggre:latest"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+        required: true
+      goose-migration:
+        condition: service_completed_successfully
+        required: true
     restart: always
     ports:
       - "443:443"
@@ -15,6 +20,27 @@ services:
       - rss-aggre-network
     secrets:
       - db_password
+
+  # Runs migration once and exits
+  goose-migration:
+    image: "horriblename/goose:latest"
+    depends_on:
+      db:
+        condition: service_healthy
+        required: true
+    restart: "no"
+    environment:
+      DATABASE_HOST: db
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
+      POSTGRES_USER: rss-aggre
+    volumes:
+      - ../sql/schema:/schema
+      - ./update_schema.sh:/usr/local/bin/docker_entrypoint.sh
+    entrypoint: /usr/local/bin/docker_entrypoint.sh
+    secrets:
+      - db_password
+    networks:
+      - rss-aggre-network
 
   db:
     image: "postgres:15.4-alpine3.18"
@@ -31,6 +57,14 @@ services:
       - db_password
     networks:
       - rss-aggre-network
+
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "rss-aggre"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 2m
+      start_interval: 5s
 
 secrets:
   db_password:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,8 +10,9 @@ services:
     environment:
       POSTGRES_PASSWORD_FILE: /run/secrets/db_password
       POSTGRES_USER: rss-aggre
+      PG_DATA: "/var/lib/postgresql/data/pgdata"
     volumes:
-      - db_data:/var/lib/postgres/data
+      - db_data:/var/lib/postgresql/data
     secrets:
       - db_password
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - db
     restart: always
     ports:
-      - "8080:80"
+      - "443:443"
     environment:
       DATABASE_URL: "user=rss-aggre host=db port=5432 sslmode=disable"
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,6 +1,20 @@
 services:
-  # rss-aggre:
-  #   build: ..
+  rss-aggre:
+    image: "rss-aggre:latest"
+    depends_on:
+      - db
+    restart: always
+    ports:
+      - "8080:80"
+    environment:
+      DATABASE_URL: "user=rss-aggre host=db port=5432 sslmode=disable"
+
+      # added specifically for docker images
+      DATABASE_PASSWORD_FILE: "/run/secrets/db_password"
+    networks:
+      - rss-aggre-network
+    secrets:
+      - db_password
 
   db:
     image: "postgres:15.4-alpine3.18"
@@ -15,10 +29,15 @@ services:
       - db_data:/var/lib/postgresql/data
     secrets:
       - db_password
+    networks:
+      - rss-aggre-network
 
 secrets:
   db_password:
     file: ./db_password.txt
+
+networks:
+  rss-aggre-network:
 
 volumes:
   db_data:

--- a/deploy/update_schema.sh
+++ b/deploy/update_schema.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+>&2
+
+if [ -n "$POSTGRES_PASSWORD_FILE" ] && [ -f "$POSTGRES_PASSWORD_FILE" ]; then
+	POSTGRES_PASSWORD="$(cat "$POSTGRES_PASSWORD_FILE")"
+fi
+
+DATABASE_HOST="${DATABASE_HOST:-localhost}"
+DATABASE_PORT="${DATABASE_PORT:-5432}"
+
+database="rss-aggre"
+
+url="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${database}"
+
+echo "Executing database migration with goose"
+
+cd /schema && goose postgres "$url" up

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
       inherit (pkgsFor.${system}) rss-aggre webclient;
       dockerStream = with pkgsFor.${system};
         dockerTools.streamLayeredImage {
-          name = "rss-aggre";
+          name = "horriblename/rss-aggre";
           tag = "latest";
 
           # I don't wanna deal with TLS certs so I'm stealing them from alpine :p
@@ -35,13 +35,6 @@
             imageDigest = "sha256:f3334cc04a79d50f686efc0c84e3048cfb0961aba5f044c7422bd99b815610d3";
             sha256 = "sha256-snYCbJocC3VLcVvOJzlujtHcJAHJHExhxoq/9r3yYvI=";
           };
-
-          # copyToRoot = buildEnv {
-          #   name = "rss-aggre";
-          #   pathsToLink = ["/bin"];
-          #   paths = [
-          #   ];
-          # };
 
           contents = [self.packages.${system}.rss-aggre];
 
@@ -66,6 +59,22 @@
             Entrypoint = [
             ];
           };
+        };
+      # Image with goose installed, doesn't do anything by default
+      gooseImageStream = let
+        inherit (pkgsFor.${system}) dockerTools goose;
+      in
+        dockerTools.streamLayeredImage {
+          name = "horriblename/goose";
+          tag = "latest";
+
+          fromImage = dockerTools.pullImage {
+            imageName = "alpine";
+            imageDigest = "sha256:f3334cc04a79d50f686efc0c84e3048cfb0961aba5f044c7422bd99b815610d3";
+            sha256 = "sha256-snYCbJocC3VLcVvOJzlujtHcJAHJHExhxoq/9r3yYvI=";
+          };
+
+          contents = [goose];
         };
     });
     devShells = eachSystem (system: let

--- a/flake.nix
+++ b/flake.nix
@@ -28,11 +28,13 @@
         dockerTools.streamLayeredImage {
           name = "rss-aggre";
           tag = "latest";
-          # fromImage = dockerTools.pullImage {
-          #   imageName = "alpine";
-          #   imageDigest = "sha256:f3334cc04a79d50f686efc0c84e3048cfb0961aba5f044c7422bd99b815610d3";
-          #   sha256 = "sha256-snYCbJocC3VLcVvOJzlujtHcJAHJHExhxoq/9r3yYvI=";
-          # };
+
+          # I don't wanna deal with TLS certs so I'm stealing them from alpine :p
+          fromImage = dockerTools.pullImage {
+            imageName = "alpine";
+            imageDigest = "sha256:f3334cc04a79d50f686efc0c84e3048cfb0961aba5f044c7422bd99b815610d3";
+            sha256 = "sha256-snYCbJocC3VLcVvOJzlujtHcJAHJHExhxoq/9r3yYvI=";
+          };
 
           # copyToRoot = buildEnv {
           #   name = "rss-aggre";
@@ -55,6 +57,11 @@
               # formatted as a psql connection string
               # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
               ''DATABASE_URL="user=rss-aggre host=localhost port=5432"''
+
+              # Path to file containing db password; can be used alongside DATABASE_URL
+              # This is intended to be used in conjunction with docker secrets
+              # example: "/run/secrets/db_password.txt"
+              "DATABASE_PASSWORD_FILE=''"
             ];
             Entrypoint = [
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
   in {
     overlays = {
       default = final: prev: {
-        rss-aggre = final.callPackage ./rss-aggre.nix {};
+        rss-aggre = final.callPackage ./nix/rss-aggre.nix {};
         webclient = final.callPackage ./webclient {};
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -18,12 +18,15 @@
       default = final: prev: {
         rss-aggre = final.callPackage ./nix/rss-aggre.nix {};
         webclient = final.callPackage ./webclient {};
+        rss-aggre-nixos-deploy-script = final.callPackage ./nix/nixos-deploy.nix {rss-aggre-src = self;};
       };
     };
 
+    nixosModules.default = import ./nix/module.nix;
+
     packages = eachSystem (system: {
       default = self.packages.${system}.rss-aggre;
-      inherit (pkgsFor.${system}) rss-aggre webclient;
+      inherit (pkgsFor.${system}) rss-aggre webclient rss-aggre-nixos-deploy-script;
       dockerStream = with pkgsFor.${system};
         dockerTools.streamLayeredImage {
           name = "horriblename/rss-aggre";

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,6 @@
       default = final: prev: {
         rss-aggre = final.callPackage ./nix/rss-aggre.nix {};
         webclient = final.callPackage ./webclient {};
-        rss-aggre-nixos-deploy-script = final.callPackage ./nix/nixos-deploy.nix {rss-aggre-src = self;};
       };
     };
 
@@ -26,7 +25,7 @@
 
     packages = eachSystem (system: {
       default = self.packages.${system}.rss-aggre;
-      inherit (pkgsFor.${system}) rss-aggre webclient rss-aggre-nixos-deploy-script;
+      inherit (pkgsFor.${system}) rss-aggre webclient;
       dockerStream = pkgsFor.${system}.callPackage ./nix/rssAggreDockerStream.nix {};
       # Image with goose installed, doesn't do anything by default
       gooseImageStream = pkgsFor.${system}.callPackage ./nix/gooseDockerStream.nix {};

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,42 @@
     packages = eachSystem (system: {
       default = self.packages.${system}.rss-aggre;
       inherit (pkgsFor.${system}) rss-aggre webclient;
+      dockerStream = with pkgsFor.${system};
+        dockerTools.streamLayeredImage {
+          name = "rss-aggre";
+          tag = "latest";
+          # fromImage = dockerTools.pullImage {
+          #   imageName = "alpine";
+          #   imageDigest = "sha256:f3334cc04a79d50f686efc0c84e3048cfb0961aba5f044c7422bd99b815610d3";
+          #   sha256 = "sha256-snYCbJocC3VLcVvOJzlujtHcJAHJHExhxoq/9r3yYvI=";
+          # };
+
+          # copyToRoot = buildEnv {
+          #   name = "rss-aggre";
+          #   pathsToLink = ["/bin"];
+          #   paths = [
+          #   ];
+          # };
+
+          contents = [self.packages.${system}.rss-aggre];
+
+          config = {
+            Cmd = ["/bin/rss-aggre"];
+            ExposedPorts = {
+              "80" = {};
+              "443" = {};
+            };
+            Env = [
+              "PORT=80"
+
+              # formatted as a psql connection string
+              # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+              ''DATABASE_URL="user=rss-aggre host=localhost port=5432"''
+            ];
+            Entrypoint = [
+            ];
+          };
+        };
     });
     devShells = eachSystem (system: let
       pkgs = pkgsFor.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -27,58 +27,9 @@
     packages = eachSystem (system: {
       default = self.packages.${system}.rss-aggre;
       inherit (pkgsFor.${system}) rss-aggre webclient rss-aggre-nixos-deploy-script;
-      dockerStream = with pkgsFor.${system};
-        dockerTools.streamLayeredImage {
-          name = "horriblename/rss-aggre";
-          tag = "latest";
-
-          # I don't wanna deal with TLS certs so I'm stealing them from alpine :p
-          fromImage = dockerTools.pullImage {
-            imageName = "alpine";
-            imageDigest = "sha256:f3334cc04a79d50f686efc0c84e3048cfb0961aba5f044c7422bd99b815610d3";
-            sha256 = "sha256-snYCbJocC3VLcVvOJzlujtHcJAHJHExhxoq/9r3yYvI=";
-          };
-
-          contents = [self.packages.${system}.rss-aggre];
-
-          config = {
-            Cmd = ["/bin/rss-aggre"];
-            ExposedPorts = {
-              "80" = {};
-              "443" = {};
-            };
-            Env = [
-              "PORT=80"
-
-              # formatted as a psql connection string
-              # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-              ''DATABASE_URL="user=rss-aggre host=localhost port=5432"''
-
-              # Path to file containing db password; can be used alongside DATABASE_URL
-              # This is intended to be used in conjunction with docker secrets
-              # example: "/run/secrets/db_password.txt"
-              "DATABASE_PASSWORD_FILE=''"
-            ];
-            Entrypoint = [
-            ];
-          };
-        };
+      dockerStream = pkgsFor.${system}.callPackage ./nix/rssAggreDockerStream.nix {};
       # Image with goose installed, doesn't do anything by default
-      gooseImageStream = let
-        inherit (pkgsFor.${system}) dockerTools goose;
-      in
-        dockerTools.streamLayeredImage {
-          name = "horriblename/goose";
-          tag = "latest";
-
-          fromImage = dockerTools.pullImage {
-            imageName = "alpine";
-            imageDigest = "sha256:f3334cc04a79d50f686efc0c84e3048cfb0961aba5f044c7422bd99b815610d3";
-            sha256 = "sha256-snYCbJocC3VLcVvOJzlujtHcJAHJHExhxoq/9r3yYvI=";
-          };
-
-          contents = [goose];
-        };
+      gooseImageStream = pkgsFor.${system}.callPackage ./nix/gooseDockerStream.nix {};
     });
     devShells = eachSystem (system: let
       pkgs = pkgsFor.${system};

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -48,6 +49,17 @@ func main() {
 	if dbURL == "" {
 		log.Print("missing env var $DATABASE_URL")
 		os.Exit(1)
+	}
+	dbPasswordFile := os.Getenv("DATABASE_PASSWORD_FILE")
+	if dbPasswordFile != "" {
+		pwd, err := os.ReadFile(dbPasswordFile)
+		if err != nil {
+			log.Fatalf("error reading DATABASE_PASSWORD_FILE(%s): %s", dbPasswordFile, err)
+		}
+
+		// escape "'" and "\" + delete newlines
+		sanitized := strings.NewReplacer("'", `\'`, `\`, `\\`, "\n", "").Replace((string(pwd)))
+		dbURL = fmt.Sprintf("%s password='%s'", dbURL, sanitized)
 	}
 
 	port := os.Getenv("PORT")

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func startServer(serverCfg serverConfig, apiCfg apiConfig) error {
 
 	server := http.Server{
 		Handler: router,
-		Addr:    "localhost:" + serverCfg.port,
+		Addr:    ":" + serverCfg.port,
 	}
 
 	log.Printf("starting server...")

--- a/nix/gooseDockerStream.nix
+++ b/nix/gooseDockerStream.nix
@@ -1,0 +1,16 @@
+{
+  dockerTools,
+  goose,
+}:
+dockerTools.streamLayeredImage {
+  name = "horriblename/goose";
+  tag = "latest";
+
+  fromImage = dockerTools.pullImage {
+    imageName = "alpine";
+    imageDigest = "sha256:f3334cc04a79d50f686efc0c84e3048cfb0961aba5f044c7422bd99b815610d3";
+    sha256 = "sha256-snYCbJocC3VLcVvOJzlujtHcJAHJHExhxoq/9r3yYvI=";
+  };
+
+  contents = [goose];
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -72,14 +72,14 @@ in {
         wantedBy = ["multi-user.target"];
         after = ["rss-aggre.target"];
 
-        path = [cfg.goosePackage cfg.package.migrations];
+        path = [cfg.goosePackage];
         serviceConfig = {
           User = "rss-aggre";
           Group = "rss-aggre";
           Type = "oneshot";
+          WorkingDirectory = toString cfg.package.migrations;
           ExecStart = pkgs.writeShellScript "rss-aggre-migration-script" ''
             set -e
-            cd ${cfg.package.migrations}
             connString='${connString}'
 
             exec goose postgres "$connString" up

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,73 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}: let
+  inherit (lib) types;
+  cfg = config.options.services.rss-aggre;
+in {
+  options.services.rss-aggre = {
+    enable = lib.mkEnableOption "RSS aggregator service";
+    databaseUser = lib.mkOption {
+      description = "Postgres Database user";
+      type = types.str;
+      default = "rss-aggre";
+    };
+    databasePasswordFile = lib.mkOption {
+      description = "Path to file containing database password";
+      type = types.str;
+      default = "";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.postgresql.enable = true;
+    services.postgresql.package = pkgs.postgresql_15;
+
+    users.users.rss-aggre = {
+      name = "rss-aggre";
+      group = "rss-aggre";
+      description = "RSS Aggregator server user";
+      useDefaultShell = true;
+    };
+
+    environment.systemPackages = [pkgs.rss-aggre];
+
+    systemd.services.rss-aggre-db-migration = {
+      description = "RSS Aggregator Database Migration";
+      wantedBy = ["multi-user.target"];
+      after = ["rss-aggre.target"];
+
+      path = [pkgs.goose];
+      serviceConfig = {
+        User = "rss-aggre";
+        Group = "rss-aggre";
+        Type = "oneshot";
+        ExecStart = pkgs.writeShellScript ''
+          DB_PASSWORD="$(cat ${cfg.databasePasswordFile} | sed -e 's/\\/\\\\/g' -e "s/'/\\\\'/g")"
+          DB_URL="user=${cfg.databaseUser} host=localhost port=5432 password='$DB_PASSWORD' sslmode=disable"
+
+          exec goose postgres "$DB_URL" up
+        '';
+      };
+    };
+
+    systemd.services.rss-aggre = {
+      description = "RSS Aggregator Server";
+      wantedBy = ["multi-user.target"];
+      after = ["postgresql.target"];
+
+      path = [pkgs.rss-aggre];
+      serviceConfig = {
+        User = "rss-aggre";
+        Group = "rss-aggre";
+        Type = "exec";
+
+        TimeoutSec = 120;
+
+        ExecStart = "${lib.getExe pkgs.rss-aggre}";
+      };
+    };
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -5,69 +5,108 @@
   ...
 }: let
   inherit (lib) types;
-  cfg = config.options.services.rss-aggre;
+  cfg = config.services.rss-aggre;
 in {
   options.services.rss-aggre = {
     enable = lib.mkEnableOption "RSS aggregator service";
-    databaseUser = lib.mkOption {
-      description = "Postgres Database user";
-      type = types.str;
-      default = "rss-aggre";
+    package = lib.mkOption {
+      description = "RSS Aggregator package";
+      type = types.package;
+      default = pkgs.rss-aggre;
     };
-    databasePasswordFile = lib.mkOption {
-      description = "Path to file containing database password";
-      type = types.str;
-      default = "";
+    goosePackage = lib.mkOption {
+      description = "Goose package, used for database migrations";
+      type = types.package;
+      default = pkgs.goose;
+    };
+    postgres = {
+      # user = lib.mkOption {
+      #   description = "Postgres Database user";
+      #   type = types.str;
+      #   default = "rss-aggre";
+      # };
+      dbName = lib.mkOption {
+        description = "The database name to use";
+        type = types.str;
+        default = "rss-aggre";
+      };
+      # passwordFile = lib.mkOption {
+      #   description = "Path to file containing database password";
+      #   type = types.str;
+      #   default = "";
+      # };
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    services.postgresql.enable = true;
-    services.postgresql.package = pkgs.postgresql_15;
-
-    users.users.rss-aggre = {
-      name = "rss-aggre";
-      group = "rss-aggre";
-      description = "RSS Aggregator server user";
-      useDefaultShell = true;
-    };
-
-    environment.systemPackages = [pkgs.rss-aggre];
-
-    systemd.services.rss-aggre-db-migration = {
-      description = "RSS Aggregator Database Migration";
-      wantedBy = ["multi-user.target"];
-      after = ["rss-aggre.target"];
-
-      path = [pkgs.goose];
-      serviceConfig = {
-        User = "rss-aggre";
-        Group = "rss-aggre";
-        Type = "oneshot";
-        ExecStart = pkgs.writeShellScript ''
-          DB_PASSWORD="$(cat ${cfg.databasePasswordFile} | sed -e 's/\\/\\\\/g' -e "s/'/\\\\'/g")"
-          DB_URL="user=${cfg.databaseUser} host=localhost port=5432 password='$DB_PASSWORD' sslmode=disable"
-
-          exec goose postgres "$DB_URL" up
-        '';
+  config = lib.mkIf cfg.enable (
+    let
+      pgUser = "rss-aggre";
+      connString = "user=${pgUser} host=${config.services.postgresql.dataDir} dbname=${cfg.postgres.dbName}";
+      rssAggrePort = "12080";
+    in {
+      services.postgresql = {
+        enable = true;
+        # ensureUsers uses peer authentication: checks OS username against DB username (local only)
+        ensureUsers = [
+          {name = pgUser;}
+        ];
       };
-    };
 
-    systemd.services.rss-aggre = {
-      description = "RSS Aggregator Server";
-      wantedBy = ["multi-user.target"];
-      after = ["postgresql.target"];
+      services.caddy.configFile = ''
+        reverse_proxy :80 ${rssAggrePort}
+      '';
 
-      path = [pkgs.rss-aggre];
-      serviceConfig = {
-        User = "rss-aggre";
-        Group = "rss-aggre";
-        Type = "exec";
-
-        TimeoutSec = 120;
-
-        ExecStart = "${lib.getExe pkgs.rss-aggre}";
+      users.users.rss-aggre = {
+        isNormalUser = true;
+        name = "rss-aggre";
+        group = "rss-aggre";
+        description = "RSS Aggregator server user";
+        useDefaultShell = true;
       };
-    };
-  };
+      users.groups.rss-aggre = {};
+
+      environment.systemPackages = [cfg.package];
+
+      systemd.services.rss-aggre-db-migration = {
+        description = "RSS Aggregator Database Migration";
+        wantedBy = ["multi-user.target"];
+        after = ["rss-aggre.target"];
+
+        path = [cfg.goosePackage cfg.package.migrations];
+        serviceConfig = {
+          User = "rss-aggre";
+          Group = "rss-aggre";
+          Type = "oneshot";
+          ExecStart = pkgs.writeShellScript "rss-aggre-migration-script" ''
+            set -e
+            cd ${cfg.package.migrations}
+            connString='${connString}'
+
+            exec goose postgres "$connString" up
+          '';
+        };
+      };
+
+      systemd.services.rss-aggre = {
+        description = "RSS Aggregator Server";
+        wantedBy = ["multi-user.target"];
+        after = ["postgresql.target"];
+        environment = {
+          PORT = rssAggrePort;
+          DATABASE_URL = connString;
+        };
+
+        path = [cfg.package];
+        serviceConfig = {
+          User = "rss-aggre";
+          Group = "rss-aggre";
+          Type = "exec";
+
+          TimeoutSec = 120;
+
+          ExecStart = "${lib.getExe cfg.package}";
+        };
+      };
+    }
+  );
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -77,7 +77,7 @@ in {
           User = "rss-aggre";
           Group = "rss-aggre";
           Type = "oneshot";
-          WorkingDirectory = toString cfg.package.migrations;
+          WorkingDirectory = "${cfg.package}/share/rss-aggre/schema";
           ExecStart = pkgs.writeShellScript "rss-aggre-migration-script" ''
             set -e
             connString='${connString}'

--- a/nix/rss-aggre.nix
+++ b/nix/rss-aggre.nix
@@ -3,7 +3,7 @@ buildGoModule {
   pname = "rss-aggre";
   version = "0.1";
 
-  src = ./.;
+  src = ../.;
   vendorHash = "sha256-lX+5edOBfwmuik8C3+OPLlizR3iDg7VK+Ov0gh4BRM8=";
 
   meta = {

--- a/nix/rss-aggre.nix
+++ b/nix/rss-aggre.nix
@@ -1,16 +1,28 @@
-{buildGoModule}:
-buildGoModule {
-  pname = "rss-aggre";
-  version = "0.1";
+{
+  buildGoModule,
+  lib,
+}: let
+  inherit (lib.sources) cleanSourceWith cleanSourceFilter;
+in
+  buildGoModule {
+    pname = "rss-aggre";
+    version = "0.1";
 
-  src = ../.;
-  vendorHash = "sha256-lX+5edOBfwmuik8C3+OPLlizR3iDg7VK+Ov0gh4BRM8=";
+    src = cleanSourceWith {
+      filter = cleanSourceFilter;
+      src = cleanSourceWith {
+        filter = name: _type: ! (lib.hasSuffix ".nix" (toString name));
+        src = ../.;
+      };
+    };
 
-  outputs = ["out"];
+    vendorHash = "sha256-lX+5edOBfwmuik8C3+OPLlizR3iDg7VK+Ov0gh4BRM8=";
 
-  migrations = ../sql/schema;
+    outputs = ["out"];
 
-  meta = {
-    mainProgram = "rss-aggre";
-  };
-}
+    migrations = ../sql/schema;
+
+    meta = {
+      mainProgram = "rss-aggre";
+    };
+  }

--- a/nix/rss-aggre.nix
+++ b/nix/rss-aggre.nix
@@ -6,6 +6,10 @@ buildGoModule {
   src = ../.;
   vendorHash = "sha256-lX+5edOBfwmuik8C3+OPLlizR3iDg7VK+Ov0gh4BRM8=";
 
+  outputs = ["out"];
+
+  migrations = ../sql/schema;
+
   meta = {
     mainProgram = "rss-aggre";
   };

--- a/nix/rss-aggre.nix
+++ b/nix/rss-aggre.nix
@@ -3,24 +3,29 @@
   lib,
 }: let
   inherit (lib.sources) cleanSourceWith cleanSourceFilter;
+
+  src = cleanSourceWith {
+    filter = cleanSourceFilter;
+    src = cleanSourceWith {
+      filter = name: _type: ! (lib.hasSuffix ".nix" (toString name));
+      src = ../.;
+    };
+  };
 in
   buildGoModule {
     pname = "rss-aggre";
     version = "0.1";
 
-    src = cleanSourceWith {
-      filter = cleanSourceFilter;
-      src = cleanSourceWith {
-        filter = name: _type: ! (lib.hasSuffix ".nix" (toString name));
-        src = ../.;
-      };
-    };
+    inherit src;
 
     vendorHash = "sha256-lX+5edOBfwmuik8C3+OPLlizR3iDg7VK+Ov0gh4BRM8=";
 
     outputs = ["out"];
 
-    migrations = ../sql/schema;
+    postInstall = ''
+      mkdir -p $out/share/rss-aggre
+      cp -r ${src}/sql/schema $out/share/rss-aggre
+    '';
 
     meta = {
       mainProgram = "rss-aggre";

--- a/nix/rssAggreDockerStream.nix
+++ b/nix/rssAggreDockerStream.nix
@@ -1,0 +1,39 @@
+{
+  dockerTools,
+  rss-aggre,
+}:
+dockerTools.streamLayeredImage {
+  name = "horriblename/rss-aggre";
+  tag = "latest";
+
+  # I don't wanna deal with TLS certs so I'm stealing them from alpine :p
+  fromImage = dockerTools.pullImage {
+    imageName = "alpine";
+    imageDigest = "sha256:f3334cc04a79d50f686efc0c84e3048cfb0961aba5f044c7422bd99b815610d3";
+    sha256 = "sha256-snYCbJocC3VLcVvOJzlujtHcJAHJHExhxoq/9r3yYvI=";
+  };
+
+  contents = [rss-aggre];
+
+  config = {
+    Cmd = ["/bin/rss-aggre"];
+    ExposedPorts = {
+      "80" = {};
+      "443" = {};
+    };
+    Env = [
+      "PORT=80"
+
+      # formatted as a psql connection string
+      # https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+      ''DATABASE_URL="user=rss-aggre host=localhost port=5432"''
+
+      # Path to file containing db password; can be used alongside DATABASE_URL
+      # This is intended to be used in conjunction with docker secrets
+      # example: "/run/secrets/db_password.txt"
+      "DATABASE_PASSWORD_FILE=''"
+    ];
+    Entrypoint = [
+    ];
+  };
+}

--- a/rss-aggre.nix
+++ b/rss-aggre.nix
@@ -5,4 +5,8 @@ buildGoModule {
 
   src = ./.;
   vendorHash = "sha256-lX+5edOBfwmuik8C3+OPLlizR3iDg7VK+Ov0gh4BRM8=";
+
+  meta = {
+    mainProgram = "rss-aggre";
+  };
 }

--- a/webclient/src/ApiUrl.elm
+++ b/webclient/src/ApiUrl.elm
@@ -3,4 +3,4 @@ module ApiUrl exposing (apiBaseUrl)
 
 apiBaseUrl : String
 apiBaseUrl =
-    ""
+    "http://horriblename.site"

--- a/webclient/src/ApiUrl.elm
+++ b/webclient/src/ApiUrl.elm
@@ -1,0 +1,6 @@
+module ApiUrl exposing (apiBaseUrl)
+
+
+apiBaseUrl : String
+apiBaseUrl =
+    ""

--- a/webclient/src/Feed.elm
+++ b/webclient/src/Feed.elm
@@ -1,10 +1,10 @@
 module Feed exposing (Feed, FeedFollow, UUID, createFeed, fetchFeeds, fetchFollows, followFeed, unfollowFeed)
 
+import ApiUrl exposing (apiBaseUrl)
 import Http exposing (header)
 import Json.Decode as Decode exposing (Decoder, list, string)
 import Json.Decode.Pipeline exposing (optional, required)
 import Json.Encode as Encode
-import Route exposing (apiBaseUrl)
 
 
 type alias Feed =

--- a/webclient/src/Post.elm
+++ b/webclient/src/Post.elm
@@ -1,10 +1,10 @@
 module Post exposing (Post, fetchPosts)
 
+import ApiUrl exposing (apiBaseUrl)
 import Http exposing (header)
 import Iso8601
 import Json.Decode as Decode exposing (Decoder, andThen, list, maybe, string)
 import Json.Decode.Pipeline exposing (optional, required)
-import Route exposing (apiBaseUrl)
 import Time
 
 

--- a/webclient/src/User.elm
+++ b/webclient/src/User.elm
@@ -1,9 +1,9 @@
 module User exposing (User, registerUser)
 
+import ApiUrl exposing (apiBaseUrl)
 import Http exposing (stringBody)
 import Json.Decode as Decode exposing (Decoder, string)
 import Json.Decode.Pipeline exposing (hardcoded, optional, required)
-import Route exposing (apiBaseUrl)
 
 
 


### PR DESCRIPTION
This PR adds a docker-compose and a NixOS module. The docker-compose should honestly be removed,
the NixOS module is the current preferred method of deployment.

- fix(deploy): wrong path for persistent db
- fix(server): why did I bind to localhost only??
- deploy: add server to docker-compose
- nix: export mainProgram
- feat(nix): add docker stream package
- fix(deploy): workaround TLS issues by building on alpine
- deploy: change default port to 443
- nix: create oci image for goose
- deploy: run db migrations before starting server
- internal(webclient): separate apiBaseUrl into another module
- dev(make): add convenience targets for pushing images and deploying
- cleanup
- cleanup: move nix files into nix/
- nix: expose migration schemas
- nix: add nixos module
- fixup! nix: add nixos module
- nix: clean source before build
- nix: use systemd builtins instead of cd
- fix(nix): copy migration schema to output
- nix module: expose port
- fix(client): update api url
